### PR TITLE
remove py-starbound submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "starcheat/starbound"]
-	path = starcheat/starbound
-	url = https://github.com/blixt/py-starbound.git
-	branch = master

--- a/build.py
+++ b/build.py
@@ -42,11 +42,6 @@ def main():
                     ignore=shutil.ignore_patterns("templates", "starbound", "images", "*.qrc"))
 
     if options.verbose:
-        print("Copying py-starbound module")
-    shutil.copytree(os.path.join(src_dir, "starcheat", "starbound", "starbound"),
-                    os.path.join(prefix, "starbound"))
-
-    if options.verbose:
         print("Generating python Qt templates...")
     for t in templates:
         temp = os.path.join(src_dir, "starcheat", "templates", t)

--- a/starcheat/assets/core.py
+++ b/starcheat/assets/core.py
@@ -8,8 +8,6 @@ import re
 import sqlite3
 import logging
 
-import starbound
-import starbound.btreedb4
 import assets.sb_asset
 
 from assets.blueprints import Blueprints


### PR DESCRIPTION
This PR removes the now obsolete [`py-starbound`](py-starbound) submodule.
