### PR TITLE
improved build.py + hide menubar icons on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,6 @@ Here is how to build starcheat from source. Make sure everything in the dependen
 - [PyQt5](http://www.riverbankcomputing.com/software/pyqt/download5)
 - [Qt 5](http://qt-project.org/downloads) (included in PyQt5 binaries on Windows)
 - [Pillow](https://pypi.python.org/pypi/Pillow/)
-- [py-starbound](https://github.com/blixt/py-starbound)
-
-**NOTE:** py-starbound is included as a [git submodule](http://git-scm.com/docs/git-submodule) and needs to be cloned with the following commands:
-
-- ```cd <starcheat top folder>```
-- ```git submodule sync```
-- ```git submodule update --init```
-
-Applications such as [Sourcetree](http://www.sourcetreeapp.com/) should offer to clone it automatically.
 
 ### Windows
 Lines starting with ```>``` can be run in PowerShell or cmd.exe.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,6 @@ init:
 
 install:
   - REG ADD HKCU\Software\Python\PythonCore\3.4\InstallPath /f /ve /t REG_SZ /d %PYTHON%
-  - git submodule update --init --recursive
   - ps: Start-FileDownload $env:PyQT -FileName $env:temp/pyqt5_install.exe
   - ps: "& $env:temp/pyqt5_install.exe /S"
   - ps: "Wait-Process -Name pyqt5_install -Timeout 600"

--- a/build.py
+++ b/build.py
@@ -1,24 +1,31 @@
 #!/usr/bin/env python3
 
-import os, platform, shutil
-from optparse import OptionParser
+import os
+import platform
+import shutil
+from argparse import ArgumentParser
+
 
 def main():
     desc = "builds starbound using pyqt5 and python3"
     if platform.system() == "Windows":
         desc += " (with cx_freeze if --with-exe is passed)"
-    parser = OptionParser(description=desc)
-    parser.add_option("-p", "--prefix", "-b", "--build", "--build-dir", dest="prefix", default="build",
-                      help="build and install starboud to this prefix (default to build)")
-    parser.add_option("-v", "--verbose", dest="verbose", action="store_true", help="print status messages to stdout")
-    if platform.system() == "Windows":
-        parser.add_option("-e", "--exe", "--with-exe", "--enable-exe", action="store_true", dest="exe",
-                          help="generates .exe (windows only)")
-        parser.add_option("-d", "--dist", "--dist-dir", dest="dist", default="dist",
-                          help="generates .exe to this dir (default to dist)")
-    (options, args) = parser.parse_args()
+    parser = ArgumentParser(description=desc)
+    parser.add_argument("-p", "--prefix", "-b", "--build", "--build-dir", dest="prefix", default="build",
+                        help="build and install starboud to this prefix (default to build)")
+    parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", default=True,
+                        help="print status messages to stdout")
+    parser.add_argument("-q", "--quiet", dest="verbose", action="store_false", default=True,
+                        help="don't print status messages to stdout")
 
-    src_dir = os.path.dirname(os.path.realpath(__file__));
+    if platform.system() == "Windows":
+        parser.add_argument("-e", "--exe", "--with-exe", "--enable-exe", action="store_true", dest="exe",
+                            help="generates .exe (windows only)")
+        parser.add_argument("-d", "--dist", "--dist-dir", dest="dist", default="dist",
+                            help="generates .exe to this dir (default to dist)")
+    options = parser.parse_args()
+
+    src_dir = os.path.dirname(os.path.realpath(__file__))
     templates = os.listdir(os.path.join(src_dir, "starcheat", "templates"))
     prefix = os.path.expanduser(options.prefix)
     if platform.system() == "Windows":
@@ -80,7 +87,7 @@ def main():
             print("Launching cx_freeze...")
         icon_path = os.path.join(src_dir, "starcheat", "images", "starcheat.ico")
         os.system("python " + cx_freeze_Path + " \"" + os.path.join(prefix, "starcheat.py") + "\" --target-dir=\"" +
-                  dist + "\" --base-name=Win32GUI --icon=\"" + icon_path +"\"")
+                  dist + "\" --base-name=Win32GUI --icon=\"" + icon_path + "\"")
         shutil.copy(os.path.join(pyqt5_dir, "libEGL.dll"), dist)
 
         if options.verbose:

--- a/starcheat/gui/mainwindow.py
+++ b/starcheat/gui/mainwindow.py
@@ -5,6 +5,7 @@ Main application window for Starcheat GUI
 import sys
 import logging
 import json
+import platform
 
 from PyQt5 import QtWidgets
 from PyQt5 import QtCore
@@ -75,6 +76,9 @@ class MainWindow():
         update_result = [None]
         update_thread = Thread(target=update_check_worker, args=[update_result], daemon=True)
         update_thread.start()
+
+        if platform.system() == "Darwin":
+            QApplication.setAttribute(QtCore.Qt.AA_DontShowIconsInMenus)
 
         """Display the main Starcheat window."""
         self.app = QApplication(sys.argv)


### PR DESCRIPTION
- switch from deprecated OptionParser to ArgumentParser
- default to verbose build
- added quite option (-q, —quite)
- also removed submodule documentation + ci command

Fixes https://github.com/wizzomafizzo/starcheat/issues/299

(This is part 1 of the build process rewrite.)
- hides menubar icons on macOS

Fixes https://github.com/wizzomafizzo/starcheat/issues/296
