### PR TITLE
handle invalid JSON (empty, trailing comma) during asset import + style fixes

### DIFF
--- a/starcheat/assets/blueprints.py
+++ b/starcheat/assets/blueprints.py
@@ -7,10 +7,7 @@ class Blueprints():
         self.starbound_folder = assets.starbound_folder
 
     def is_blueprint(self, key):
-        if key.endswith(".recipe"):
-            return True
-        else:
-            return False
+        return key.endswith(".recipe")
 
     def index_data(self, asset):
         key = asset[0]
@@ -49,7 +46,6 @@ class Blueprints():
 
     def get_blueprint(self, name):
         c = self.assets.db.cursor()
-        print(name)
         c.execute("select key, path, desc from assets where type = 'blueprint' and name = ?", (name,))
         meta = c.fetchone()
         if meta is not None:

--- a/starcheat/assets/frames.py
+++ b/starcheat/assets/frames.py
@@ -7,10 +7,7 @@ class Frames(object):
         self.starbound_folder = assets.starbound_folder
 
     def is_frames(self, key):
-        if key.endswith(".frames"):
-            return True
-        else:
-            return False
+        return key.endswith(".frames")
 
     def index_data(self, asset):
         key = asset[0]

--- a/starcheat/assets/items.py
+++ b/starcheat/assets/items.py
@@ -51,16 +51,8 @@ class Items(object):
         self.starbound_folder = assets.starbound_folder
 
     def is_item(self, key):
-        if key.endswith(".object"):
-            return True
-        elif key.endswith(".techitem"):
-            return True
-        elif key.endswith(".codexitem"):
-            return True
-        elif key.startswith("items", 1) and re.match(ignore_items, key) is None:
-            return True
-        else:
-            return False
+        return (key.endswith(".object") or key.endswith(".techitem") or key.endswith(".codexitem") or
+                (key.startswith("items", 1) and re.match(ignore_items, key) is None))
 
     def index_data(self, asset):
         key = asset[0]
@@ -139,7 +131,7 @@ class Items(object):
 
         icon_file = item[0]["inventoryIcon"]
         if not isinstance(icon_file, str):
-            icon_name =  [icon_file[0]['image']]
+            icon_name = [icon_file[0]['image']]
         else:
             icon_name = icon_file.split(':')
         if len(icon_name) < 2:

--- a/starcheat/assets/monsters.py
+++ b/starcheat/assets/monsters.py
@@ -8,10 +8,7 @@ class Monsters(object):
         self.starbound_folder = assets.starbound_folder
 
     def is_monster(self, key):
-        if key.endswith(".monstertype"):
-            return True
-        else:
-            return False
+        return key.endswith(".monstertype")
 
     def index_data(self, asset):
         key = asset[0]

--- a/starcheat/assets/species.py
+++ b/starcheat/assets/species.py
@@ -25,10 +25,7 @@ class Species(object):
         self.starbound_folder = assets.starbound_folder
 
     def is_species(self, key):
-        if key.endswith(".species"):
-            return True
-        else:
-            return False
+        return key.endswith(".species")
 
     def index_data(self, asset):
         key = asset[0]
@@ -121,9 +118,7 @@ class Species(object):
             return groups
 
     def get_personality(self):
-        config = self.assets.read("/humanoid.config",
-                                  self.assets.vanilla_assets)
-        print(config)
+        config = self.assets.read("/humanoid.config", self.assets.vanilla_assets)
         return config["personalities"]
 
     def get_gender_data(self, species_data, gender):

--- a/starcheat/assets/techs.py
+++ b/starcheat/assets/techs.py
@@ -11,10 +11,7 @@ class Techs():
         self.starbound_folder = assets.starbound_folder
 
     def is_tech(self, key):
-        if key.endswith(".tech"):
-            return True
-        else:
-            return False
+        return key.endswith(".tech")
 
     def index_data(self, asset):
         key = asset[0]

--- a/starcheat/saves.py
+++ b/starcheat/saves.py
@@ -529,7 +529,7 @@ class PlayerSave(object):
         contents.append(self.entity["inventory"]["customBar"][0][5])
         logging.info(contents)
         return contents
-        
+
     def get_action_bar_2(self):
         contents = []
         contents.append(self.entity["inventory"]["customBar"][1][0])


### PR DESCRIPTION
This PR fixes the 2 instances during asset import were pythons strict JSON decoder would throw because of a invalid JSON:
- empty ` `instead of`{}`in`/monster/dungeon/glitchspider/default.frames`
- a trailing comma in `/object/wired/invisiblesound/invisiblesoundhidden.frames`)

After this PR we are catching this error and instead of rethrowing it (current behavior) we clean up the JSON and retry with the now valid JSON. I'm not cleaning every JSON but only the 2 invalid ones for performance reasons.

This PR fixes also some style issues, which should reduce code duplication too and make Codacy finally happy with the 1.0 support PR (at least I hope so).
